### PR TITLE
Refactors pact:publish script to properly read from env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "./node_modules/.bin/jest",
     "test:consumer": "nyc --check-coverage --reporter=html --reporter=text-summary mocha consumer/*.spec.ts",
     "test:provider": "nyc --check-coverage --reporter=html --reporter=text-summary mocha -t 20000 provider/*.spec.ts",
-    "pact:publish": "pact-broker publish ./pacts --consumer-app-version=1.0.0 --broker-base-url=$PACT_BROKER_URL --broker-token=$PACT_BROKER_TOKEN"
+    "pact:publish": "scripts/publishPact.sh"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/publishPact.sh
+++ b/scripts/publishPact.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pact-broker publish ./pacts --consumer-app-version=1.0.0 --broker-base-url=$PACT_BROKER_BASE_URL --broker-token=$PACT_BROKER_TOKEN


### PR DESCRIPTION
It seems like the `package.json` cannot read from environment variables. In order to read from environment variables, I extracted it out to bash script and am calling that bash script in `pact:publish`. 

### Pre:
- [x] Merge https://github.com/teespring-labs/pact-mock-feed-service/pull/1